### PR TITLE
Renamed default config to server to avoid the const fallacy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-w -s" -o
 FROM alpine:3.13
 RUN mkdir /app && cd /app
 WORKDIR /app
-COPY server.config.yaml default.config.yaml
+COPY server.config.yaml server.config.yaml
 COPY --from=backend-builder /app/nuts-registry-admin-demo .
 HEALTHCHECK --start-period=5s --timeout=5s --interval=5s \
     CMD wget --no-verbose --tries=1 --spider http://localhost:1303/ || exit 1

--- a/config.go
+++ b/config.go
@@ -20,7 +20,7 @@ import (
 const defaultPrefix = "NUTS_"
 const defaultDelimiter = "."
 const configFileFlag = "configfile"
-const defaultConfigFile = "default.config.yaml"
+const defaultConfigFile = "server.config.yaml"
 const defaultDBFile = "registry-admin.db"
 const defaultHTTPPort = 1303
 


### PR DESCRIPTION
Reasoning:

1. A const named "default" should contain the default value, not literally "default".
2. When you override `default.config.yaml` in the Docker image with your own, it technically isn't the default config anymore.