### PR TITLE
Use default config if no config file found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,6 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-w -s" -o
 FROM alpine:3.13
 RUN mkdir /app && cd /app
 WORKDIR /app
-COPY server.config.yaml server.config.yaml
 COPY --from=backend-builder /app/nuts-registry-admin-demo .
 HEALTHCHECK --start-period=5s --timeout=5s --interval=5s \
     CMD wget --no-verbose --tries=1 --spider http://localhost:1303/ || exit 1

--- a/README.md
+++ b/README.md
@@ -33,8 +33,5 @@ $ docker run -p 1303:1303 nutsfoundation/nuts-registry-admin-demo
 ```
 
 ## Configuration
-You can configure the application by changing the values in `server.config.yaml`.
-
-The Default http port is `1303`.
-
-Credentials to get a session: user:`demo@nuts.nl` password:`demo`.
+When running in Docker without a config file mounted at `/app/server.config.yaml` it will use the default configuration.
+In this case the default username will be `demo@nuts.nl`. The password is generated and printed in the log on startup.

--- a/config.go
+++ b/config.go
@@ -61,8 +61,14 @@ func loadConfig() Config {
 
 	var k = koanf.New(".")
 
-	if err := k.Load(file.Provider(resolveConfigFile(flagset)), yaml.Parser()); err != nil {
-		log.Fatalf("error while loading config from file: %v", err)
+	configFile := resolveConfigFile(flagset)
+	if _, err := os.Stat(configFile); err == nil {
+		log.Printf("Loading config from file: %s", configFile)
+		if err := k.Load(file.Provider(configFile), yaml.Parser()); err != nil {
+			log.Fatalf("error while loading config from file: %v", err)
+		}
+	} else {
+		log.Printf("Using default config because no file was found at: %s", configFile)
 	}
 
 	config := defaultConfig()
@@ -111,6 +117,5 @@ func resolveConfigFile(flagset *pflag.FlagSet) string {
 	_ = k.Load(posflag.Provider(flagset, defaultDelimiter, k), nil)
 
 	configFile := k.String(configFileFlag)
-	log.Printf("using config: %s", configFile)
 	return configFile
 }


### PR DESCRIPTION
This way the default password is generated on startup, which is much safer than the hardcoded which is currently copied into the Docker image.