### PR TITLE
Fixed issue that caused environment configuration to be ignored

### DIFF
--- a/config.go
+++ b/config.go
@@ -102,6 +102,9 @@ func loadConfig() Config {
 		log.Printf("Using default config because no file was found at: %s", configFilePath)
 	}
 
+	// load env flags, can't return error
+	_ = k.Load(envProvider(), nil)
+
 	config := defaultConfig()
 	var err error
 	sessionKey, err := generateSessionKey()
@@ -137,17 +140,19 @@ func resolveConfigFile(flagset *pflag.FlagSet) string {
 
 	k := koanf.New(defaultDelimiter)
 
-	// load env flags
-	e := env.Provider(defaultPrefix, defaultDelimiter, func(s string) string {
-		return strings.Replace(strings.ToLower(
-			strings.TrimPrefix(s, defaultPrefix)), "_", defaultDelimiter, -1)
-	})
-	// can't return error
-	_ = k.Load(e, nil)
+	// load env flags, can't return error
+	_ = k.Load(envProvider(), nil)
 
 	// load cmd flags, without a parser, no error can be returned
 	_ = k.Load(posflag.Provider(flagset, defaultDelimiter, k), nil)
 
 	configFile := k.String(configFileFlag)
 	return configFile
+}
+
+func envProvider() *env.Env {
+	return env.Provider(defaultPrefix, defaultDelimiter, func(s string) string {
+		return strings.Replace(strings.ToLower(
+			strings.TrimPrefix(s, defaultPrefix)), "_", defaultDelimiter, -1)
+	})
 }


### PR DESCRIPTION
Fixes #76 by copying some code from https://github.com/ivido/nuts-demo-ehr

```
$ NUTS_BRANDING_LOGO=https://cdn.shopify.com/s/files/1/0018/9890/5651/products/Candle_shopify_DN_1800x1800.jpg go run .
2022/03/06 17:08:00 Loading config from file: server.config.yaml
========== CONFIG: ==========
&{0xc000088120} {
  "Credentials": {
    "Username": "demo@nuts.nl"
  },
  "DBFile": "registry-admin.db",
  "HTTPPort": 1303,
  "NutsNodeAddress": "http://localhost:1323",
  "CustomersFile": "customers.json",
  "Branding": {
    "Logo": "https://cdn.shopify.com/s/files/1/0018/9890/5651/products/Candle_shopify_DN_1800x1800.jpg"
  }
}
========= END CONFIG =========
```