### PR TITLE
Make VC templates v5 compliant

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -54,12 +54,6 @@ func (w Wrapper) GetVCTemplates(ctx echo.Context) error {
 			PublishToNetwork: true,
 			Visibility:       "private",
 			CredentialSubject: map[string]interface{}{
-				"legalBase": map[string]interface{}{
-					"consentType": "implied",
-				},
-				"localParameters": map[string]interface{}{
-					"example": "parameter",
-				},
 				"resources": []map[string]interface{}{
 					{
 						"path":        "/DocumentReference/f2aeec97-fc0d-42bf-8ca7-0548192d4231",


### PR DESCRIPTION
Also removed `localParameters`: although specified by the Bolt they require an (embedded?) JSON-LD-context to fill properly, which people using the UI probably find too hard.