### PR TITLE
VCR: Copy VC search query type from Nuts node

### DIFF
--- a/domain/credentials/service.go
+++ b/domain/credentials/service.go
@@ -83,9 +83,9 @@ func (s Service) GetCredentials(customer domain.Customer) ([]domain.Organization
 	return s.search(SearchVCQuery{
 		Type:    []ssi.URI{ssi.MustParseURI(credential.NutsOrganizationCredentialType), ssi.MustParseURI(vc.VerifiableCredentialType)},
 		Context: []ssi.URI{ssi.MustParseURI(vc.VCContextV1), ssi.MustParseURI(credential.NutsV1Context)},
-		CredentialSubject: []interface{}{domain.NutsOrganizationCredentialSubject{
+		CredentialSubject: domain.NutsOrganizationCredentialSubject{
 			ID: *customer.Did,
-		}},
+		},
 	})
 }
 
@@ -99,12 +99,12 @@ func (s Service) SearchOrganizations(name, city string) ([]domain.OrganizationCo
 	return s.search(SearchVCQuery{
 		Type:    []ssi.URI{ssi.MustParseURI(credential.NutsOrganizationCredentialType), ssi.MustParseURI(vc.VerifiableCredentialType)},
 		Context: []ssi.URI{ssi.MustParseURI(vc.VCContextV1), ssi.MustParseURI(credential.NutsV1Context)},
-		CredentialSubject: []interface{}{domain.NutsOrganizationCredentialSubject{
+		CredentialSubject: domain.NutsOrganizationCredentialSubject{
 			Organization: domain.Organization{
 				Name: name,
 				City: city,
 			},
-		}},
+		},
 	})
 }
 

--- a/domain/credentials/service.go
+++ b/domain/credentials/service.go
@@ -80,7 +80,7 @@ func (s Service) ManageNutsOrgCredential(customer domain.Customer, shouldHaveCre
 }
 
 func (s Service) GetCredentials(customer domain.Customer) ([]domain.OrganizationConceptCredential, error) {
-	return s.search(vcrApi.SearchVCQuery{
+	return s.search(SearchVCQuery{
 		Type:    []ssi.URI{ssi.MustParseURI(credential.NutsOrganizationCredentialType), ssi.MustParseURI(vc.VerifiableCredentialType)},
 		Context: []ssi.URI{ssi.MustParseURI(vc.VCContextV1), ssi.MustParseURI(credential.NutsV1Context)},
 		CredentialSubject: []interface{}{domain.NutsOrganizationCredentialSubject{
@@ -96,7 +96,7 @@ func (s Service) SearchOrganizations(name, city string) ([]domain.OrganizationCo
 	if len(city) > 0 {
 		city += "*"
 	}
-	return s.search(vcrApi.SearchVCQuery{
+	return s.search(SearchVCQuery{
 		Type:    []ssi.URI{ssi.MustParseURI(credential.NutsOrganizationCredentialType), ssi.MustParseURI(vc.VerifiableCredentialType)},
 		Context: []ssi.URI{ssi.MustParseURI(vc.VCContextV1), ssi.MustParseURI(credential.NutsV1Context)},
 		CredentialSubject: []interface{}{domain.NutsOrganizationCredentialSubject{
@@ -108,11 +108,12 @@ func (s Service) SearchOrganizations(name, city string) ([]domain.OrganizationCo
 	})
 }
 
-func (s Service) search(credential vcrApi.SearchVCQuery) ([]domain.OrganizationConceptCredential, error) {
+func (s Service) search(credential SearchVCQuery) ([]domain.OrganizationConceptCredential, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	response, err := s.client().SearchVCs(ctx, vcrApi.SearchVCsJSONRequestBody{Query: credential})
+	requestData, _ := json.Marshal(credential)
+	response, err := s.client().SearchVCsWithBody(ctx, "application/json", bytes.NewReader(requestData))
 
 	if err != nil {
 		return nil, domain.UnwrapAPIError(err)

--- a/domain/credentials/vcr.go
+++ b/domain/credentials/vcr.go
@@ -1,0 +1,23 @@
+package credentials
+
+import (
+	ssi "github.com/nuts-foundation/go-did"
+	v2 "github.com/nuts-foundation/nuts-node/vcr/api/v2"
+)
+
+// SearchVCRequest is the request body for searching VCs
+type SearchVCRequest struct {
+	// A partial VerifiableCredential in JSON-LD format. Each field will be used to match credentials against. All fields MUST be present.
+	Query         SearchVCQuery     `json:"query"`
+	SearchOptions *v2.SearchOptions `json:"searchOptions,omitempty"`
+}
+
+// SearchVCQuery defines a helper struct to search for VerifiableCredentials.
+type SearchVCQuery struct {
+	// Context defines the json-ld context to dereference the URIs
+	Context []ssi.URI `json:"@context"`
+	// Type holds multiple types for a credential. A credential must always have the 'VerifiableCredential' type.
+	Type []ssi.URI `json:"type,omitempty"`
+	// CredentialSubject holds the actual data for the credential. It must be extracted using the UnmarshalCredentialSubject method and a custom type.
+	CredentialSubject []interface{} `json:"credentialSubject,omitempty"`
+}

--- a/domain/credentials/vcr.go
+++ b/domain/credentials/vcr.go
@@ -19,5 +19,5 @@ type SearchVCQuery struct {
 	// Type holds multiple types for a credential. A credential must always have the 'VerifiableCredential' type.
 	Type []ssi.URI `json:"type,omitempty"`
 	// CredentialSubject holds the actual data for the credential. It must be extracted using the UnmarshalCredentialSubject method and a custom type.
-	CredentialSubject []interface{} `json:"credentialSubject,omitempty"`
+	CredentialSubject interface{} `json:"credentialSubject,omitempty"`
 }


### PR DESCRIPTION
Required since https://github.com/nuts-foundation/nuts-node/pull/1967 will remove the type from Nuts-node.

Would be a typical type for a client SDK, but there is none, so for now copy is the best approach.